### PR TITLE
add displacement.glsl

### DIFF
--- a/transitions/displacement.glsl
+++ b/transitions/displacement.glsl
@@ -1,0 +1,22 @@
+// Author: Travis Fischer
+// License: MIT
+//
+// Adapted from a Codrops article by Robin Delaporte
+// https://tympanus.net/Development/DistortionHoverEffect
+
+uniform sampler2D displacementMap;
+
+uniform float strength; // = 0.5
+
+vec4 transition (vec2 uv) {
+  float displacement = texture2D(displacementMap, uv).r * strength;
+
+  vec2 uvFrom = vec2(uv.x + progress * displacement, uv.y);
+  vec2 uvTo = vec2(uv.x - (1.0 - progress) * displacement, uv.y);
+
+  return mix(
+    getFromColor(uvFrom),
+    getToColor(uvTo),
+    progress
+  );
+}


### PR DESCRIPTION
it'd be great if the default texture for `displacementMap` could use one of the more complicated patterns from the original article https://tympanus.net/Development/DistortionHoverEffect