### PR TITLE
support transparency in transitions that assumed black background

### DIFF
--- a/transitions/ButterflyWaveScrawler.glsl
+++ b/transitions/ButterflyWaveScrawler.glsl
@@ -3,6 +3,7 @@
 uniform float amplitude; // = 1.0
 uniform float waves; // = 30.0
 uniform float colorSeparation; // = 0.3
+uniform bool transparentMode; // = false
 float PI = 3.14159265358979323846264;
 float compute(vec2 p, float progress, vec2 center) {
 vec2 o = p*sin(progress * amplitude)-center;
@@ -23,6 +24,6 @@ vec4 transition(vec2 uv) {
   getFromColor(p + progress*disp*(1.0 - colorSeparation)).r,
   getFromColor(p + progress*disp).g,
   getFromColor(p + progress*disp*(1.0 + colorSeparation)).b,
-  1.0);
+  transparentMode ? getFromColor(p).a : 1.0);
   return texTo*progress + texFrom*inv;
 }

--- a/transitions/CrossZoom.glsl
+++ b/transitions/CrossZoom.glsl
@@ -7,6 +7,7 @@
 // With additional easing functions from https://github.com/rectalogic/rendermix-basic-effects/blob/master/assets/com/rendermix/Easing/Easing.glsllib
 
 uniform float strength; // = 0.4
+uniform bool transparentMode; // = false
 
 const float PI = 3.141592653589793;
 
@@ -33,8 +34,8 @@ float rand (vec2 co) {
   return fract(sin(dot(co.xy ,vec2(12.9898,78.233))) * 43758.5453);
 }
 
-vec3 crossFade(in vec2 uv, in float dissolve) {
-    return mix(getFromColor(uv).rgb, getToColor(uv).rgb, dissolve);
+vec4 crossFade(in vec2 uv, in float dissolve) {
+    return mix(getFromColor(uv).rgba, getToColor(uv).rgba, dissolve);
 }
 
 vec4 transition(vec2 uv) {
@@ -47,7 +48,7 @@ vec4 transition(vec2 uv) {
     // Mirrored sinusoidal loop. 0->strength then strength->0
     float strength = Sinusoidal_easeInOut(0.0, strength, 0.5, progress);
 
-    vec3 color = vec3(0.0);
+    vec4 color = vec4(0.0);
     float total = 0.0;
     vec2 toCenter = center - texCoord;
 
@@ -60,5 +61,9 @@ vec4 transition(vec2 uv) {
         color += crossFade(texCoord + toCenter * percent * strength, dissolve) * weight;
         total += weight;
     }
-    return vec4(color / total, 1.0);
+    vec4 result = vec4(color / total);
+    if (!transparentMode) {
+        result.a = 1.0;
+    }
+    return result;
 }

--- a/transitions/GlitchDisplace.glsl
+++ b/transitions/GlitchDisplace.glsl
@@ -1,6 +1,9 @@
 // Author: Matt DesLauriers
 // License: MIT
 
+uniform bool usebgcolor; // = false
+uniform vec4 bgcolor; // = vec4(0.0, 0.0, 0.0, 1.0)
+
 highp float random(vec2 co)
 {
     highp float a = 12.9898;
@@ -64,7 +67,7 @@ vec4 transition(vec2 uv) {
   vec4 dColor2 = getFromColor(disp2);
   float val = ease1(progress);
   vec3 gray = vec3(dot(min(dColor2, dColor1).rgb, vec3(0.299, 0.587, 0.114)));
-  dColor2 = vec4(gray, 1.0);
+  dColor2 = usebgcolor ? bgcolor : vec4(gray, 1.0);
   dColor2 *= 2.0;
   color1 = mix(color1, dColor2, smoothstep(0.0, 0.5, progress));
   color2 = mix(color2, dColor1, smoothstep(1.0, 0.5, progress));

--- a/transitions/GlitchDisplace.glsl
+++ b/transitions/GlitchDisplace.glsl
@@ -1,8 +1,7 @@
 // Author: Matt DesLauriers
 // License: MIT
 
-uniform bool usebgcolor; // = false
-uniform vec4 bgcolor; // = vec4(0.0, 0.0, 0.0, 1.0)
+uniform bool transparentMode; // = false
 
 highp float random(vec2 co)
 {
@@ -67,7 +66,7 @@ vec4 transition(vec2 uv) {
   vec4 dColor2 = getFromColor(disp2);
   float val = ease1(progress);
   vec3 gray = vec3(dot(min(dColor2, dColor1).rgb, vec3(0.299, 0.587, 0.114)));
-  dColor2 = usebgcolor ? bgcolor : vec4(gray, 1.0);
+  dColor2 = vec4(gray, transparentMode ? 0.0 : 1.0);
   dColor2 *= 2.0;
   color1 = mix(color1, dColor2, smoothstep(0.0, 0.5, progress));
   color2 = mix(color2, dColor1, smoothstep(1.0, 0.5, progress));

--- a/transitions/GlitchMemories.glsl
+++ b/transitions/GlitchMemories.glsl
@@ -1,6 +1,7 @@
 // author: Gunnar Roth
 // based on work from natewave
 // license: MIT
+uniform bool transparentMode; // = false
 vec4 transition(vec2 p) {
   vec2 block = floor(p.xy / vec2(16));
   vec2 uv_noise = block / vec2(64);
@@ -10,6 +11,11 @@ vec4 transition(vec2 p) {
   vec2 green = p + dist * .3;
   vec2 blue = p + dist * .5;
 
-  return vec4(mix(getFromColor(red), getToColor(red), progress).r,mix(getFromColor(green), getToColor(green), progress).g,mix(getFromColor(blue), getToColor(blue), progress).b,1.0);
+  float alpha = 1.0;
+  if (transparentMode) {
+    // blend all the alphas...
+    alpha = (mix(getFromColor(red), getToColor(red), progress).a + mix(getFromColor(green), getToColor(green), progress).a + mix(getFromColor(blue), getToColor(blue), progress).a) / 3.0;
+  }
+  return vec4(mix(getFromColor(red), getToColor(red), progress).r,mix(getFromColor(green), getToColor(green), progress).g,mix(getFromColor(blue), getToColor(blue), progress).b,alpha);
 }
 

--- a/transitions/InvertedPageCurl.glsl
+++ b/transitions/InvertedPageCurl.glsl
@@ -34,6 +34,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 in vec2 texCoord;
 */
 
+uniform bool transparentMode; // = false
+
 const float MIN_AMOUNT = -0.16;
 const float MAX_AMOUNT = 1.5;
 float amount = progress * (MAX_AMOUNT - MIN_AMOUNT) + MIN_AMOUNT;
@@ -138,7 +140,7 @@ vec4 behindSurface(vec2 p, float yc, vec3 point, mat3 rrotation)
         {
                 shado = 0.0;
         }
-        return vec4(getToColor(p).rgb - shado, 1.0);
+        return vec4(getToColor(p).rgb - shado, transparentMode ? getToColor(p).a : 1.0);
 }
 
 vec4 transition(vec2 p) {

--- a/transitions/StereoViewer.glsl
+++ b/transitions/StereoViewer.glsl
@@ -3,6 +3,8 @@
 uniform float zoom; // = 0.88
 // Corner radius as a fraction of the image height
 uniform float corner_radius;  // = 0.22
+uniform bool usebgcolor; // = false
+uniform vec4 bgcolor; // = vec4(0.0, 0.0, 0.0, 1.0)
 
 // author: Ted Schundler
 // license: BSD 2 Clause
@@ -27,7 +29,7 @@ uniform float corner_radius;  // = 0.22
 // There is a quick zoom in / out to make the transition 'valid' for GLSL.io //
 ///////////////////////////////////////////////////////////////////////////////
 
-const vec4 black = vec4(0.0, 0.0, 0.0, 1.0);
+vec4 black = usebgcolor ? bgcolor : vec4(0.0, 0.0, 0.0, 1.0);
 const vec2 c00 = vec2(0.0, 0.0); // the four corner points
 const vec2 c01 = vec2(0.0, 1.0);
 const vec2 c11 = vec2(1.0, 1.0);

--- a/transitions/StereoViewer.glsl
+++ b/transitions/StereoViewer.glsl
@@ -3,8 +3,7 @@
 uniform float zoom; // = 0.88
 // Corner radius as a fraction of the image height
 uniform float corner_radius;  // = 0.22
-uniform bool usebgcolor; // = false
-uniform vec4 bgcolor; // = vec4(0.0, 0.0, 0.0, 1.0)
+uniform bool transparentMode; // = false
 
 // author: Ted Schundler
 // license: BSD 2 Clause
@@ -29,7 +28,7 @@ uniform vec4 bgcolor; // = vec4(0.0, 0.0, 0.0, 1.0)
 // There is a quick zoom in / out to make the transition 'valid' for GLSL.io //
 ///////////////////////////////////////////////////////////////////////////////
 
-vec4 black = usebgcolor ? bgcolor : vec4(0.0, 0.0, 0.0, 1.0);
+vec4 black = vec4(0.0, 0.0, 0.0, transparentMode ? 0.0 : 1.0);
 const vec2 c00 = vec2(0.0, 0.0); // the four corner points
 const vec2 c01 = vec2(0.0, 1.0);
 const vec2 c11 = vec2(1.0, 1.0);

--- a/transitions/burn.glsl
+++ b/transitions/burn.glsl
@@ -1,10 +1,11 @@
 // author: gre
 // License: MIT
 uniform vec3 color /* = vec3(0.9, 0.4, 0.2) */;
+uniform vec4 bgcolor; // = vec4(0.0, 0.0, 0.0, 1.0)
 vec4 transition (vec2 uv) {
   return mix(
-    getFromColor(uv) + vec4(progress*color, 1.0),
-    getToColor(uv) + vec4((1.0-progress)*color, 1.0),
+    getFromColor(uv) + vec4(progress*color, bgcolor.a),
+    getToColor(uv) + vec4((1.0-progress)*color, bgcolor.a),
     progress
   );
 }

--- a/transitions/burn.glsl
+++ b/transitions/burn.glsl
@@ -1,11 +1,11 @@
 // author: gre
 // License: MIT
 uniform vec3 color /* = vec3(0.9, 0.4, 0.2) */;
-uniform vec4 bgcolor; // = vec4(0.0, 0.0, 0.0, 1.0)
+uniform bool transparentMode; // = false
 vec4 transition (vec2 uv) {
   return mix(
-    getFromColor(uv) + vec4(progress*color, bgcolor.a),
-    getToColor(uv) + vec4((1.0-progress)*color, bgcolor.a),
+    getFromColor(uv) + vec4(progress*color, transparentMode ? 0.0 : 1.0),
+    getToColor(uv) + vec4((1.0-progress)*color, transparentMode ? 0.0 : 1.0),
     progress
   );
 }

--- a/transitions/circle.glsl
+++ b/transitions/circle.glsl
@@ -3,8 +3,7 @@
 
 uniform vec2 center; // = vec2(0.5, 0.5);
 uniform vec3 backColor; // = vec3(0.1, 0.1, 0.1);
-uniform bool usebgcolor; // = false;
-uniform vec4 bgcolor; // = vec4(0.0, 0.0, 0.0, 1.0)
+uniform bool transparentMode; // = false
 
 vec4 transition (vec2 uv) {
   
@@ -12,10 +11,7 @@ vec4 transition (vec2 uv) {
   float radius = sqrt(8.0) * abs(progress - 0.5);
   
   if (distance > radius) {
-    if (usebgcolor) {
-      return bgcolor;
-    }
-    return vec4(backColor, 1.0);
+    return vec4(backColor, transparentMode ? 0.0 : 1.0);
   }
   else {
     if (progress < 0.5) return getFromColor(uv);

--- a/transitions/circle.glsl
+++ b/transitions/circle.glsl
@@ -3,6 +3,8 @@
 
 uniform vec2 center; // = vec2(0.5, 0.5);
 uniform vec3 backColor; // = vec3(0.1, 0.1, 0.1);
+uniform bool usebgcolor; // = false;
+uniform vec4 bgcolor; // = vec4(0.0, 0.0, 0.0, 1.0)
 
 vec4 transition (vec2 uv) {
   
@@ -10,6 +12,9 @@ vec4 transition (vec2 uv) {
   float radius = sqrt(8.0) * abs(progress - 0.5);
   
   if (distance > radius) {
+    if (usebgcolor) {
+      return bgcolor;
+    }
     return vec4(backColor, 1.0);
   }
   else {

--- a/transitions/cube.glsl
+++ b/transitions/cube.glsl
@@ -4,7 +4,7 @@ uniform float persp; // = 0.7
 uniform float unzoom; // = 0.3
 uniform float reflection; // = 0.4
 uniform float floating; // = 3.0
-uniform vec4 bgcolor; // = vec4(0.0, 0.0, 0.0, 1.0)
+uniform bool transparentMode; // = false
 
 vec2 project (vec2 p) {
   return p * vec2(1.0, -1.2) + vec2(0.0, -floating/100.);
@@ -15,7 +15,7 @@ bool inBounds (vec2 p) {
 }
 
 vec4 bgColor (vec2 p, vec2 pfr, vec2 pto) {
-  vec4 c = bgcolor;
+  vec4 c = vec4(0.0, 0.0, 0.0, transparentMode ? 0.0 : 1.0);
   pfr = project(pfr);
   // FIXME avoid branching might help perf!
   if (inBounds(pfr)) {

--- a/transitions/cube.glsl
+++ b/transitions/cube.glsl
@@ -4,6 +4,7 @@ uniform float persp; // = 0.7
 uniform float unzoom; // = 0.3
 uniform float reflection; // = 0.4
 uniform float floating; // = 3.0
+uniform vec4 bgcolor; // = vec4(0.0, 0.0, 0.0, 1.0)
 
 vec2 project (vec2 p) {
   return p * vec2(1.0, -1.2) + vec2(0.0, -floating/100.);
@@ -14,7 +15,7 @@ bool inBounds (vec2 p) {
 }
 
 vec4 bgColor (vec2 p, vec2 pfr, vec2 pto) {
-  vec4 c = vec4(0.0, 0.0, 0.0, 1.0);
+  vec4 c = bgcolor;
   pfr = project(pfr);
   // FIXME avoid branching might help perf!
   if (inBounds(pfr)) {

--- a/transitions/doorway.glsl
+++ b/transitions/doorway.glsl
@@ -3,8 +3,8 @@
 uniform float reflection; // = 0.4
 uniform float perspective; // = 0.4
 uniform float depth; // = 3
+uniform vec4 bgcolor; // = vec4(0.0, 0.0, 0.0, 1.0)
 
-const vec4 black = vec4(0.0, 0.0, 0.0, 1.0);
 const vec2 boundMin = vec2(0.0, 0.0);
 const vec2 boundMax = vec2(1.0, 1.0);
 
@@ -17,10 +17,10 @@ vec2 project (vec2 p) {
 }
 
 vec4 bgColor (vec2 p, vec2 pto) {
-  vec4 c = black;
+  vec4 c = bgcolor;
   pto = project(pto);
   if (inBounds(pto)) {
-    c += mix(black, getToColor(pto), reflection * mix(1.0, 0.0, pto.y));
+    c += mix(bgcolor, getToColor(pto), reflection * mix(1.0, 0.0, pto.y));
   }
   return c;
 }

--- a/transitions/doorway.glsl
+++ b/transitions/doorway.glsl
@@ -3,8 +3,9 @@
 uniform float reflection; // = 0.4
 uniform float perspective; // = 0.4
 uniform float depth; // = 3
-uniform vec4 bgcolor; // = vec4(0.0, 0.0, 0.0, 1.0)
+uniform bool transparentMode; // = false
 
+vec4 black = vec4(0.0, 0.0, 0.0, transparentMode ? 0.0 : 1.0);
 const vec2 boundMin = vec2(0.0, 0.0);
 const vec2 boundMax = vec2(1.0, 1.0);
 
@@ -17,10 +18,10 @@ vec2 project (vec2 p) {
 }
 
 vec4 bgColor (vec2 p, vec2 pto) {
-  vec4 c = bgcolor;
+  vec4 c = black;
   pto = project(pto);
   if (inBounds(pto)) {
-    c += mix(bgcolor, getToColor(pto), reflection * mix(1.0, 0.0, pto.y));
+    c += mix(black, getToColor(pto), reflection * mix(1.0, 0.0, pto.y));
   }
   return c;
 }

--- a/transitions/fadecolor.glsl
+++ b/transitions/fadecolor.glsl
@@ -2,12 +2,10 @@
 // License: MIT
 uniform vec3 color;// = vec3(0.0)
 uniform float colorPhase/* = 0.4 */; // if 0.0, there is no black phase, if 0.9, the black phase is very important
-uniform bool usebgcolor; // = false
-uniform vec4 bgcolor; // = vec4(0.0, 0.0, 0.0, 1.0)
-vec4 mixColor = usebgcolor ? bgcolor : vec4(color, 1.0);
+uniform bool transparentMode; // = false
 vec4 transition (vec2 uv) {
   return mix(
-    mix(mixColor, getFromColor(uv), smoothstep(1.0-colorPhase, 0.0, progress)),
-    mix(mixColor, getToColor(uv), smoothstep(    colorPhase, 1.0, progress)),
+    mix(vec4(color, transparentMode ? 0.0 : 1.0), getFromColor(uv), smoothstep(1.0-colorPhase, 0.0, progress)),
+    mix(vec4(color, transparentMode ? 0.0 : 1.0), getToColor(uv), smoothstep(    colorPhase, 1.0, progress)),
     progress);
 }

--- a/transitions/fadecolor.glsl
+++ b/transitions/fadecolor.glsl
@@ -2,9 +2,12 @@
 // License: MIT
 uniform vec3 color;// = vec3(0.0)
 uniform float colorPhase/* = 0.4 */; // if 0.0, there is no black phase, if 0.9, the black phase is very important
+uniform bool usebgcolor; // = false
+uniform vec4 bgcolor; // = vec4(0.0, 0.0, 0.0, 1.0)
+vec4 mixColor = usebgcolor ? bgcolor : vec4(color, 1.0);
 vec4 transition (vec2 uv) {
   return mix(
-    mix(vec4(color, 1.0), getFromColor(uv), smoothstep(1.0-colorPhase, 0.0, progress)),
-    mix(vec4(color, 1.0), getToColor(uv), smoothstep(    colorPhase, 1.0, progress)),
+    mix(mixColor, getFromColor(uv), smoothstep(1.0-colorPhase, 0.0, progress)),
+    mix(mixColor, getToColor(uv), smoothstep(    colorPhase, 1.0, progress)),
     progress);
 }

--- a/transitions/fadegrayscale.glsl
+++ b/transitions/fadegrayscale.glsl
@@ -2,6 +2,7 @@
 // License: MIT
 
 uniform float intensity; // = 0.3; // if 0.0, the image directly turn grayscale, if 0.9, the grayscale transition phase is very important
+uniform bool transparentMode; // = false
  
 vec3 grayscale (vec3 color) {
   return vec3(0.2126*color.r + 0.7152*color.g + 0.0722*color.b);
@@ -10,8 +11,9 @@ vec3 grayscale (vec3 color) {
 vec4 transition (vec2 uv) {
   vec4 fc = getFromColor(uv);
   vec4 tc = getToColor(uv);
+  float alpha = transparentMode ? (fc.a + tc.a)/2.0 : 1.0;
   return mix(
-    mix(vec4(grayscale(fc.rgb), 1.0), fc, smoothstep(1.0-intensity, 0.0, progress)),
-    mix(vec4(grayscale(tc.rgb), 1.0), tc, smoothstep(    intensity, 1.0, progress)),
+    mix(vec4(grayscale(fc.rgb), alpha), fc, smoothstep(1.0-intensity, 0.0, progress)),
+    mix(vec4(grayscale(tc.rgb), alpha), tc, smoothstep(    intensity, 1.0, progress)),
     progress);
 }

--- a/transitions/flyeye.glsl
+++ b/transitions/flyeye.glsl
@@ -3,6 +3,7 @@
 uniform float size; // = 0.04
 uniform float zoom; // = 50.0
 uniform float colorSeparation; // = 0.3
+uniform bool transparentMode; // = false
 
 vec4 transition(vec2 p) {
   float inv = 1. - progress;
@@ -12,6 +13,6 @@ vec4 transition(vec2 p) {
     getFromColor(p + progress*disp*(1.0 - colorSeparation)).r,
     getFromColor(p + progress*disp).g,
     getFromColor(p + progress*disp*(1.0 + colorSeparation)).b,
-    1.0);
+    transparentMode ? (getFromColor(p + progress*disp).a + texTo.a) / 2.0  : 1.0);
   return texTo*progress + texFrom*inv;
 }

--- a/transitions/swap.glsl
+++ b/transitions/swap.glsl
@@ -4,10 +4,9 @@
 uniform float reflection; // = 0.4
 uniform float perspective; // = 0.2
 uniform float depth; // = 3.0
- uniform bool usebgcolor; // = false
-uniform vec4 bgcolor; // = vec4(0.0, 0.0, 0.0, 1.0)
+uniform bool transparentMode; // = false
 
-vec4 black = usebgcolor ? bgcolor : vec4(0.0, 0.0, 0.0, 1.0);
+vec4 black = vec4(0.0, 0.0, 0.0, transparentMode ? 0.0 : 1.0);
 const vec2 boundMin = vec2(0.0, 0.0);
 const vec2 boundMax = vec2(1.0, 1.0);
  

--- a/transitions/swap.glsl
+++ b/transitions/swap.glsl
@@ -4,8 +4,10 @@
 uniform float reflection; // = 0.4
 uniform float perspective; // = 0.2
 uniform float depth; // = 3.0
- 
-const vec4 black = vec4(0.0, 0.0, 0.0, 1.0);
+ uniform bool usebgcolor; // = false
+uniform vec4 bgcolor; // = vec4(0.0, 0.0, 0.0, 1.0)
+
+vec4 black = usebgcolor ? bgcolor : vec4(0.0, 0.0, 0.0, 1.0);
 const vec2 boundMin = vec2(0.0, 0.0);
 const vec2 boundMax = vec2(1.0, 1.0);
  


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

If you create a new transition, or update an existing one, our bot🤖 will come to validate and render it to GIF 🙂

Last Minute Tips':
- Please check if your transition is not already covered by an existing one.
- It is great (but not mandatory) if your transitions can include uniforms parameters to be customizable by the final user.
-->

Sometimes, we want to composite a transition on top of other elements and want it to be transparent where it's not drawing, rather than opaque black.  This PR introduces a "transparencyMode" for the 14 transitions that we needed to modify to get the effect we wanted.