### PR TITLE
Update wind.glsl

### DIFF
--- a/transitions/wind.glsl
+++ b/transitions/wind.glsl
@@ -3,14 +3,16 @@
 
 // Custom parameters
 uniform float size; // = 0.2
+uniform bool reversed; // = false;
 
 float rand (vec2 co) {
   return fract(sin(dot(co.xy ,vec2(12.9898,78.233))) * 43758.5453);
 }
 
 vec4 transition (vec2 uv) {
+  float x = reversed ? 1. - uv.x : uv.x;
   float r = rand(vec2(0, uv.y));
-  float m = smoothstep(0.0, -size, uv.x*(1.0-size) + size*r - (progress * (1.0 + size)));
+  float m = smoothstep(0.0, -size, x*(1.0-size) + size*r - (progress * (1.0 + size)));
   return mix(
     getFromColor(uv),
     getToColor(uv),


### PR DESCRIPTION
Update wind.glsl
Add parameter reversed to control transition direction. By default reversed value is false.
Default transition direction from left to right.

