### PR TITLE
Add alpha support to CrossZoom.glsl

### DIFF
--- a/transitions/CrossZoom.glsl
+++ b/transitions/CrossZoom.glsl
@@ -33,8 +33,8 @@ float rand (vec2 co) {
   return fract(sin(dot(co.xy ,vec2(12.9898,78.233))) * 43758.5453);
 }
 
-vec3 crossFade(in vec2 uv, in float dissolve) {
-    return mix(getFromColor(uv).rgb, getToColor(uv).rgb, dissolve);
+vec4 crossFade(in vec2 uv, in float dissolve) {
+    return mix(getFromColor(uv), getToColor(uv), dissolve);
 }
 
 vec4 transition(vec2 uv) {
@@ -47,7 +47,7 @@ vec4 transition(vec2 uv) {
     // Mirrored sinusoidal loop. 0->strength then strength->0
     float strength = Sinusoidal_easeInOut(0.0, strength, 0.5, progress);
 
-    vec3 color = vec3(0.0);
+    vec4 color = vec4(0.0);
     float total = 0.0;
     vec2 toCenter = center - texCoord;
 
@@ -60,5 +60,5 @@ vec4 transition(vec2 uv) {
         color += crossFade(texCoord + toCenter * percent * strength, dissolve) * weight;
         total += weight;
     }
-    return vec4(color / total, 1.0);
+    return color / total;
 }


### PR DESCRIPTION
I know PRs aren't getting considered, but here's fixed support for alpha in the "Cross Zoom" transition.

I notice this has also been fixed in another way in #203 but this doesn't need to add any extra flag.
