### PR TITLE
Fix npm publish auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Build
         run: ./scripts/build.sh
@@ -39,8 +39,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
-          registry-url: https://registry.npmjs.org
+          node-version: 24
 
       - name: Build
         run: ./scripts/build.sh


### PR DESCRIPTION
## Summary

The publish step in #228 failed with `E404` because **Trusted Publishing requires npm >= 11.5.1** which ships with Node 24. Node 20's npm was too old to handle the OIDC token exchange.

Changes:
- Bump Node from 20 to 24 (for npm with OIDC support)
- Remove `registry-url` from `setup-node` (npm handles OIDC auth internally)
- Remove `NODE_AUTH_TOKEN` (not needed with Trusted Publishing)

## Setup required

Verify the Trusted Publishing config on npmjs.com matches:
- **Organization or user**: `gl-transitions`
- **Repository**: `gl-transitions`
- **Workflow filename**: `ci.yml`

No `NPM_TOKEN` secret needed.

## Test plan

- [ ] CI build passes on this PR
- [ ] After merge: npm publishes v1.44.0 successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)