### PR TITLE
Fix preview: checkout PR branch for workflow_dispatch

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -39,6 +39,14 @@ jobs:
         if: github.event_name == 'pull_request'
         run: git fetch origin master --depth=1
 
+      - name: Checkout PR branch for workflow_dispatch
+        if: github.event_name == 'workflow_dispatch' && inputs.pr_number != ''
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          git fetch origin "pull/${PR_NUMBER}/head" --depth=1
+          git checkout FETCH_HEAD -- transitions/
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20


### PR DESCRIPTION
## Summary

When manually triggering a preview for a PR via `workflow_dispatch`, the transition file only exists on the PR's branch, not on master. The workflow now fetches the PR branch and checks out its `transitions/` directory before looking for the file.

Fixes the `premiereCrossZoom` preview attempt on PR #227 which failed with "not found".

## Test plan

- [ ] After merge: re-run `workflow_dispatch` with `premiereCrossZoom` on PR #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)