### PR TITLE
Fix preview branch switch + skip publish on non-transition changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,39 @@ jobs:
       - name: Build
         run: ./scripts/build.sh
 
-  publish:
+  check-publish:
     needs: build
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    outputs:
+      should_publish: ${{ steps.check.outputs.should_publish }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check if transitions or build changed
+        id: check
+        run: |
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -z "$LAST_TAG" ]; then
+            echo "No previous tag found — will publish"
+            echo "should_publish=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          CHANGED=$(git diff --name-only "$LAST_TAG" -- transitions/ scripts/build.sh scripts/gl-transition-transform.js scripts/release-skeleton/)
+          if [ -n "$CHANGED" ]; then
+            echo "should_publish=true" >> $GITHUB_OUTPUT
+            echo "Changed files affecting package:"
+            echo "$CHANGED"
+          else
+            echo "should_publish=false" >> $GITHUB_OUTPUT
+            echo "No changes to transitions or build scripts — skipping publish"
+          fi
+
+  publish:
+    needs: check-publish
+    if: needs.check-publish.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -102,6 +102,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+          # Discard any working tree changes from PR branch checkout
+          git checkout -- . 2>/dev/null || true
+          git clean -fd 2>/dev/null || true
+
           git fetch origin preview-assets 2>/dev/null || true
           if git rev-parse --verify origin/preview-assets >/dev/null 2>&1; then
             git checkout origin/preview-assets


### PR DESCRIPTION
## Summary

**Preview fix:** The `workflow_dispatch` checkout of a PR branch can leave modified files in the working tree (e.g. `CrossZoom.glsl` differs between PR base and master). This blocks the subsequent checkout to `preview-assets` branch. Fix: reset working tree before switching.

**CI improvement:** Skip npm publish when only CI/docs/workflow files changed — no need to publish a new npm version if no transitions or build scripts were modified.

## Test plan

- [ ] After merge: re-run `workflow_dispatch` with `wind` on PR #211
- [ ] Verify that merging a CI-only PR does not trigger npm publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)