### PR TITLE
Fix preview: git reset --hard before branch switch

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -102,9 +102,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          # Discard any working tree changes from PR branch checkout
-          git checkout -- . 2>/dev/null || true
-          git clean -fd 2>/dev/null || true
+          # Reset working tree — PR branch checkout may have modified tracked files
+          git reset --hard HEAD
+          git clean -fd
 
           git fetch origin preview-assets 2>/dev/null || true
           if git rev-parse --verify origin/preview-assets >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

`git checkout -- .` wasn't enough to clean the working tree after checking out PR branch files. The index itself was dirty from `git checkout FETCH_HEAD -- transitions/`. Using `git reset --hard HEAD` properly resets both index and working tree.

## Test plan

- [ ] After merge: re-run `workflow_dispatch` with `wind` on PR #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)