### PR TITLE
Fix preview: single xvfb-run for validate + render

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -85,20 +85,20 @@ jobs:
         if: steps.detect.outputs.files != ''
         run: |
           mkdir -p /tmp/previews
-          for file in ${{ steps.detect.outputs.files }}; do
-            name=$(basename "$file" .glsl)
-            echo "=== Validating $name ==="
-            xvfb-run -s "-ac -screen 0 1280x1024x24" \
+          xvfb-run -s "-ac -screen 0 1280x1024x24" bash -c '
+            for file in ${{ steps.detect.outputs.files }}; do
+              name=$(basename "$file" .glsl)
+              echo "=== Validating $name ==="
               node scripts/preview/validate-transition.js \
-              --transition "$file" > "/tmp/previews/${name}.validation.json" 2>/dev/null || true
-            cat "/tmp/previews/${name}.validation.json"
-            echo ""
-            echo "=== Rendering $name ==="
-            xvfb-run -s "-ac -screen 0 1280x1024x24" \
+                --transition "$file" > "/tmp/previews/${name}.validation.json" 2>/dev/null || true
+              cat "/tmp/previews/${name}.validation.json"
+              echo ""
+              echo "=== Rendering $name ==="
               node scripts/preview/render-transition.js \
-              --transition "$file" \
-              --output "/tmp/previews/${name}.gif" 2>&1 || echo "Failed: $name"
-          done
+                --transition "$file" \
+                --output "/tmp/previews/${name}.gif" 2>&1 || echo "Failed: $name"
+            done
+          '
 
       - name: Upload GIFs to preview-assets branch
         if: steps.detect.outputs.files != '' && (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository)


### PR DESCRIPTION
## Summary

Preview GIFs were not being generated because the validate step and render step each used their own `xvfb-run`, but the second one fails with "Xvfb failed to start" because display :99 is already taken by the first. Same fix as test-preview.yml — wrap everything in one `xvfb-run bash -c '...'`.

## Test plan

- [ ] After merge: re-run preview on a PR and verify both validation JSON + GIF are generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)