### PR TITLE
Fix release-skeleton README: dead images, stale URLs, typos

### DIFF
--- a/scripts/release-skeleton/README.md
+++ b/scripts/release-skeleton/README.md
@@ -2,11 +2,11 @@
 
 > The open collection of GL Transitions.
 
-<img src="https://camo.githubusercontent.com/c42ecc6197b0f51a106fb50723f9bc6d2e1f925c/687474703a2f2f692e696d6775722e636f6d2f74573331704a452e676966" /> <img src="https://camo.githubusercontent.com/7e34cd12d5a9afa94f470395b04b0914c978ce01/687474703a2f2f692e696d6775722e636f6d2f555a5a727775552e676966" />
+Browse all transitions on **[gl-transitions.com](https://gl-transitions.com/)**.
 
 This package exposes an Array<Transition> auto-generated from the [GitHub repository](https://github.com/gl-transitions/gl-transitions).
 
-a Transition is an object with following shape:
+A Transition is an object with the following shape:
 
 ```js
 {
@@ -21,16 +21,15 @@ a Transition is an object with following shape:
 }
 ```
 
-For more information, please checkout https://github.com/gl-transitions/gl-transitions
-
-<img src="https://camo.githubusercontent.com/0456d4ed8753fbce027f1174dc8b22da548eeade/687474703a2f2f692e696d6775722e636f6d2f654974426a33582e676966" /> <img src="https://camo.githubusercontent.com/275453118c3efe6f0d722d7cbefba6849af5e13c/687474703a2f2f692e696d6775722e636f6d2f694d5a6e596f332e676966" />
-
+For more information, please check out the [GitHub repository](https://github.com/gl-transitions/gl-transitions).
 
 ## Install
 
-**with NPM:**
+**with npm:**
 
 ```sh
+npm install gl-transitions
+# or
 yarn add gl-transitions
 ```
 
@@ -41,7 +40,7 @@ import GLTransitions from "gl-transitions";
 **dist script:**
 
 ```
-https://unpkg.com/gl-transitions@0/gl-transitions.js
+https://unpkg.com/gl-transitions@1/gl-transitions.js
 ```
 
 ```js
@@ -51,5 +50,5 @@ const GLTransitions = window.GLTransitions
 **vanilla JSON:**
 
 ```
-https://unpkg.com/gl-transitions@0/gl-transitions.json
+https://unpkg.com/gl-transitions@1/gl-transitions.json
 ```


### PR DESCRIPTION
## Summary
- Remove 4 dead imgur GIF embeds (expired GitHub camo proxy URLs) and link to [gl-transitions.com](https://gl-transitions.com/) gallery instead
- Update unpkg URLs from `@0` to `@1` to match current major version (`1.56.0`)
- Fix minor typos: capitalize "A Transition", "checkout" → "check out", proper markdown link
- Show both `npm install` and `yarn add` in install instructions

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify unpkg URLs resolve: https://unpkg.com/gl-transitions@1/gl-transitions.js

🤖 Generated with [Claude Code](https://claude.com/claude-code)