### PR TITLE
StarWipe: fix uniform default syntax and clean up formatting

### DIFF
--- a/transitions/StarWipe.glsl
+++ b/transitions/StarWipe.glsl
@@ -1,17 +1,17 @@
-// Author:Ben Lucas
+// Author: Ben Lucas
 // License: MIT
 #define PI 3.141592653589793
 #define STAR_ANGLE 1.2566370614359172
 
-uniform float border_thickness;// = 0.01;
-uniform float star_rotation;// = 0.75;
-uniform vec4 border_color; // = vec4(1.0);
-uniform vec2 star_center;// = vec2(0.5);
+uniform float border_thickness;// = 0.01
+uniform float star_rotation;// = 0.75
+uniform vec4 border_color; // = vec4(1.0)
+uniform vec2 star_center;// = vec2(0.5)
 
 vec2 rotate(vec2 v, float theta) {
     float cosTheta = cos(theta);
     float sinTheta = sin(theta);
-    
+
     return vec2(
         cosTheta * v.x - sinTheta * v.y,
         sinTheta * v.x + cosTheta * v.y
@@ -22,17 +22,16 @@ bool inStar(vec2 uv, vec2 center, float radius){
   vec2 uv_centered = uv - center;
   uv_centered = rotate(uv_centered, star_rotation * STAR_ANGLE);
   float theta = atan(uv_centered.y, uv_centered.x) + PI;
-  
+
   vec2 uv_rotated = rotate(uv_centered, -STAR_ANGLE * (floor(theta / STAR_ANGLE) + 0.5));
-  
+
   float slope = 0.3;
   if(uv_rotated.y > 0.0){
       return (radius + uv_rotated.x * slope > uv_rotated.y);
-  } else{
+  } else {
      return (-radius - uv_rotated.x * slope < uv_rotated.y);
   }
 }
-
 
 vec4 transition (vec2 uv) {
   float progressScaled = (2.0 * border_thickness + 1.0) * progress - border_thickness;
@@ -40,9 +39,7 @@ vec4 transition (vec2 uv) {
     return getToColor(uv);
   } else if(inStar(uv, star_center, progressScaled+border_thickness)){
     return border_color;
-  }
-  else{
+  } else {
     return getFromColor(uv);
-
   }
 }


### PR DESCRIPTION
## Summary

- Remove trailing semicolons from uniform default value comments (`// = 0.01;` -> `// = 0.01`) to match the gl-transitions spec syntax for all 4 uniforms
- Add missing space after `// Author:` for consistency (`// Author: Ben Lucas`)
- Clean up formatting: remove double blank line before `vec4 transition`, remove trailing blank line inside transition function, strip trailing whitespace on blank lines
- Normalize brace style on `else` blocks (`} else{` / `}\n  else{` -> `} else {`)

No logic or algorithm changes — cosmetic and spec-compliance fixes only.

## Test plan

- [ ] Verify the transition still renders correctly (no logic changes were made)
- [ ] Confirm uniform defaults are parsed correctly by the gl-transitions tooling (no trailing semicolons)
- [ ] Review diff to confirm only whitespace/comment changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)