### PR TITLE
chessboard: fix formatting and float comparison

### DIFF
--- a/transitions/chessboard.glsl
+++ b/transitions/chessboard.glsl
@@ -1,7 +1,7 @@
-// Author:lql
+// Author: lql
 // License: MIT
 
-uniform float grid_num; // =10.0
+uniform float grid_num; // = 10.0
 
 vec4 transition(vec2 uv) {
     vec2 st = uv * grid_num;
@@ -15,9 +15,9 @@ vec4 transition(vec2 uv) {
     float mixFactor;
 
     if (progress <= 0.5) {
-        mixFactor = (checker == 1.0) ? step(grid.x, progress * 2.0) : 0.0;
+        mixFactor = (checker > 0.5) ? step(grid.x, progress * 2.0) : 0.0;
     } else {
-        mixFactor = (checker == 0.0) ? step(grid.x, (progress - 0.5) * 2.0) : 1.0;
+        mixFactor = (checker < 0.5) ? step(grid.x, (progress - 0.5) * 2.0) : 1.0;
     }
 
     return mix(a, b, mixFactor);


### PR DESCRIPTION
## Summary

- Add missing space in `// Author:lql` comment and uniform default value `// =10.0` for consistent formatting
- Replace fragile exact float equality comparisons (`== 1.0`, `== 0.0`) with threshold comparisons (`> 0.5`, `< 0.5`) to avoid floating-point precision issues in GLSL

## Test plan

- [ ] Verify the chessboard transition renders correctly with default `grid_num = 10.0`
- [ ] Confirm the transition animates properly through the full progress range (0.0 to 1.0)
- [ ] Test with different `grid_num` values to ensure the checker pattern logic is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)