### PR TITLE
zoomInOut: simplify and remove dead code

### DIFF
--- a/transitions/zoomInOut.glsl
+++ b/transitions/zoomInOut.glsl
@@ -2,28 +2,16 @@
 // License: MIT
 
 vec2 zoom(vec2 uv, float amount) {
-  return 0.5 + ((uv - 0.5) * (1.0-amount));
+  return 0.5 + ((uv - 0.5) * (1.0 - amount));
 }
 
 vec4 transition (vec2 uv) {
-  if(progress < 0.49) {
-    return mix(
-      getFromColor(zoom(uv, smoothstep(0.0, 1.0, progress * 2.0))),
-      getToColor(uv),
-      smoothstep(0.8, 1.0, progress)
-    );
-  } else if (progress < 0.51) {
-    return mix(
-    getFromColor(zoom(uv, smoothstep(0.0, 1.0, progress * 2.0))),
-    getToColor(zoom(uv, smoothstep(0.0, 1.0, (1.0 - progress) * 2.0))),
-    smoothstep(0.8, 1.0, progress)
+  float zoomFrom = smoothstep(0.0, 1.0, progress * 2.0);
+  float zoomTo = smoothstep(0.0, 1.0, (1.0 - progress) * 2.0);
+  float crossfade = smoothstep(0.4, 0.6, progress);
+  return mix(
+    getFromColor(zoom(uv, zoomFrom)),
+    getToColor(zoom(uv, zoomTo)),
+    crossfade
   );
-
-  } else {
-    return mix(
-      getToColor(zoom(uv, smoothstep(0.0, 1.0, (1.0 - progress) * 2.0))),
-      getFromColor(uv),
-      smoothstep(0.8, 1.0, 1.0 - progress)
-    );
-  }
 }


### PR DESCRIPTION
## Summary

- Remove dead code in `zoomInOut.glsl` where `mix` calls used `smoothstep` thresholds that were unreachable within their respective branches (always evaluating to 0.0)
- Replace the three-branch `if/else` structure with a single smooth crossfade using `smoothstep(0.4, 0.6, progress)`, eliminating the hard cut at `progress=0.5`
- Preserve the same zoom-in/zoom-out visual effect: `getFromColor` zooms in during the first half, crossfades, then `getToColor` zooms out during the second half

## Test plan

- [ ] Verify transition starts showing `getFromColor(uv)` at `progress=0` and ends with `getToColor(uv)` at `progress=1`
- [ ] Confirm the zoom-in effect on the source image in the first half of the transition
- [ ] Confirm the zoom-out effect on the destination image in the second half
- [ ] Verify the crossfade around `progress=0.5` is smooth (no hard cut)
- [ ] Run the shader validator to ensure the GLSL compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)