### PR TITLE
Fix preview workflow: shallow clone breaks diff on modified files

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -33,11 +33,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Fetch master for diff
         if: github.event_name == 'pull_request'
-        run: git fetch origin master --depth=1
+        run: git fetch origin master
 
       - name: Checkout PR branch for workflow_dispatch
         if: github.event_name == 'workflow_dispatch' && inputs.pr_number != ''


### PR DESCRIPTION
## Summary
- The preview workflow used `fetch-depth: 1` for both the PR checkout and the master fetch
- With two disconnected shallow histories, `git diff origin/master...HEAD` fails with `fatal: no merge base`
- This caused **all validation and GIF rendering to be silently skipped** for modified transitions (the "Detect transitions" step found no files)
- New transitions worked by luck when the PR workflow was triggered via `workflow_dispatch` with explicit file names, but the automatic `pull_request` path was broken

Fix: use `fetch-depth: 0` so git has enough history to compute the merge base.

Evidence from PR #243 run logs:
```
fatal: origin/master...HEAD: no merge base
No .glsl files changed
```

## Test plan
- [ ] After merge, re-run preview on one of the shader fix PRs (#242-#246) to confirm GIFs are generated
- [ ] Verify the preview comment is posted with validation results and GIF

🤖 Generated with [Claude Code](https://claude.com/claude-code)