### PR TITLE
Remove trailing semicolons from uniform default comments

### DIFF
--- a/transitions/BowTieWithParameter.glsl
+++ b/transitions/BowTieWithParameter.glsl
@@ -1,8 +1,8 @@
 // Author:KMojek
 // License: MIT
 
-uniform float adjust; // = 0.5;
-uniform bool reverse; // = false;
+uniform float adjust; // = 0.5
+uniform bool reverse; // = false
 
 float check(vec2 p1, vec2 p2, vec2 p3)
 {

--- a/transitions/EdgeTransition.glsl
+++ b/transitions/EdgeTransition.glsl
@@ -1,8 +1,8 @@
 // Author: Woohyun Kim
 // License: MIT
 
-uniform float edge_thickness; // = 0.001;
-uniform float edge_brightness; // = 8.0;
+uniform float edge_thickness; // = 0.001
+uniform float edge_brightness; // = 8.0
 
 vec4 detectEdgeColor(vec3[9] c) {
   /* adjacent texel array for texel c[4]

--- a/transitions/Overexposure.glsl
+++ b/transitions/Overexposure.glsl
@@ -1,7 +1,7 @@
 // Author: Ben Zhang
 // License: MIT
 
-uniform float strength; //= 0.6;
+uniform float strength; // = 0.6
 const float PI = 3.141592653589793;
 
 vec4 transition (vec2 uv) {

--- a/transitions/PolkaDotsCurtain.glsl
+++ b/transitions/PolkaDotsCurtain.glsl
@@ -1,8 +1,8 @@
 // author: bobylito
 // license: MIT
 const float SQRT_2 = 1.414213562373;
-uniform float dots;// = 20.0;
-uniform vec2 center;// = vec2(0, 0);
+uniform float dots; // = 20.0
+uniform vec2 center; // = vec2(0, 0)
 
 vec4 transition(vec2 uv) {
   bool nextImage = distance(fract(uv * dots), vec2(0.5, 0.5)) < ( progress / distance(uv, center));

--- a/transitions/angular.glsl
+++ b/transitions/angular.glsl
@@ -3,7 +3,7 @@
 
 #define PI 3.141592653589
 
-uniform float startingAngle; // = 90;
+uniform float startingAngle; // = 90
 
 vec4 transition (vec2 uv) {
   

--- a/transitions/circle.glsl
+++ b/transitions/circle.glsl
@@ -1,8 +1,8 @@
 // Author: Fernando Kuteken
 // License: MIT
 
-uniform vec2 center; // = vec2(0.5, 0.5);
-uniform vec3 backColor; // = vec3(0.1, 0.1, 0.1);
+uniform vec2 center; // = vec2(0.5, 0.5)
+uniform vec3 backColor; // = vec3(0.1, 0.1, 0.1)
 
 vec4 transition (vec2 uv) {
   

--- a/transitions/dissolve.glsl
+++ b/transitions/dissolve.glsl
@@ -5,11 +5,11 @@
 precision mediump float;
 #endif
 
-uniform float uLineWidth;// = 0.1
-uniform vec3 uSpreadClr;// = vec3(1.0, 0.0, 0.0);
-uniform vec3 uHotClr;// = vec3(0.9, 0.9, 0.2);
-uniform float uPow;// = 5.0;
-uniform float uIntensity;// = 1.0;
+uniform float uLineWidth; // = 0.1
+uniform vec3 uSpreadClr; // = vec3(1.0, 0.0, 0.0)
+uniform vec3 uHotClr; // = vec3(0.9, 0.9, 0.2)
+uniform float uPow; // = 5.0
+uniform float uIntensity; // = 1.0
 
 vec2 hash(vec2 p)  // replace this by something better
 {

--- a/transitions/hexagonalize.glsl
+++ b/transitions/hexagonalize.glsl
@@ -2,8 +2,8 @@
 // License: MIT
 // Hexagonal math from: http://www.redblobgames.com/grids/hexagons/
 
-uniform int steps; // = 50;
-uniform float horizontalHexagons; //= 20;
+uniform int steps; // = 50
+uniform float horizontalHexagons; // = 20
 
 struct Hexagon {
   float q;

--- a/transitions/kaleidoscope.glsl
+++ b/transitions/kaleidoscope.glsl
@@ -1,9 +1,9 @@
 // Author: nwoeanhinnogaehr
 // License: MIT
 
-uniform float speed; // = 1.0;
-uniform float angle; // = 1.0;
-uniform float power; // = 1.5;
+uniform float speed; // = 1.0
+uniform float angle; // = 1.0
+uniform float power; // = 1.5
 
 vec4 transition(vec2 uv) {
   vec2 p = uv.xy / vec2(1.0).xy;

--- a/transitions/pinwheel.glsl
+++ b/transitions/pinwheel.glsl
@@ -1,7 +1,7 @@
 // Author: Mr Speaker
 // License: MIT
 
-uniform float speed; // = 2.0;
+uniform float speed; // = 2.0
 
 vec4 transition(vec2 uv) {
   

--- a/transitions/polar_function.glsl
+++ b/transitions/polar_function.glsl
@@ -3,7 +3,7 @@
 
 #define PI 3.14159265359
 
-uniform int segments; // = 5;
+uniform int segments; // = 5
 
 vec4 transition (vec2 uv) {
   

--- a/transitions/powerKaleido.glsl
+++ b/transitions/powerKaleido.glsl
@@ -4,10 +4,10 @@
 #define PI 3.14159265358979
 const float rad = 120.; // change this value to get different mirror effects
 const float deg = rad / 180. * PI;
-uniform float scale; // = 2.0;
-uniform float z; // = 1.5;
+uniform float scale; // = 2.0
+uniform float z; // = 1.5
 float dist = scale / 10.;
-uniform float speed; // = 5.;
+uniform float speed; // = 5.
 vec2 refl(vec2 p,vec2 o,vec2 n)
 {
 	return 2.0*o+2.0*n*dot(p-o,n)-p;

--- a/transitions/rotate_scale_fade.glsl
+++ b/transitions/rotate_scale_fade.glsl
@@ -3,10 +3,10 @@
 
 #define PI 3.14159265359
 
-uniform vec2 center; // = vec2(0.5, 0.5);
-uniform float rotations; // = 1;
-uniform float scale; // = 8;
-uniform vec4 backColor; // = vec4(0.15, 0.15, 0.15, 1.0);
+uniform vec2 center; // = vec2(0.5, 0.5)
+uniform float rotations; // = 1
+uniform float scale; // = 8
+uniform vec4 backColor; // = vec4(0.15, 0.15, 0.15, 1.0)
 
 vec4 transition (vec2 uv) {
   

--- a/transitions/static_wipe.glsl
+++ b/transitions/static_wipe.glsl
@@ -9,8 +9,8 @@ float rnd (vec2 st) {
         12345.5453123);
 }
 
-uniform bool u_transitionUpToDown; // = true;
-uniform float u_max_static_span;// = 0.5;
+uniform bool u_transitionUpToDown; // = true
+uniform float u_max_static_span; // = 0.5
 
 vec4 transition (vec2 uv) {
   

--- a/transitions/wind.glsl
+++ b/transitions/wind.glsl
@@ -3,7 +3,7 @@
 
 // Custom parameters
 uniform float size; // = 0.2
-uniform bool reversed; // = false;
+uniform bool reversed; // = false
 
 float rand (vec2 co) {
   return fract(sin(dot(co.xy ,vec2(12.9898,78.233))) * 43758.5453);


### PR DESCRIPTION
## Summary

- Remove trailing semicolons from `// = value;` default comments in uniform declarations across 15 shader files, conforming to the gl-transitions spec (`// = value`)
- Fix missing space in `//= value` style comments (dissolve, hexagonalize, Overexposure, PolkaDotsCurtain, static_wipe) to use consistent `// = value` format
- Files fixed: angular.glsl, BowTieWithParameter.glsl, circle.glsl, dissolve.glsl, EdgeTransition.glsl, hexagonalize.glsl, kaleidoscope.glsl, Overexposure.glsl, pinwheel.glsl, polar_function.glsl, PolkaDotsCurtain.glsl, powerKaleido.glsl, rotate_scale_fade.glsl, static_wipe.glsl, wind.glsl

## Test plan

- [ ] Verify the gl-transition-scripts validator (`npm run lint`) passes for all 15 modified shaders
- [ ] Confirm uniform default values are correctly parsed (no trailing semicolons in comment portion)
- [ ] Spot-check that no GLSL code semicolons were accidentally removed (only comment content was changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)