### PR TITLE
Fix pow() with negative base in InvertedPageCurl and tangentMotionBlur

### DIFF
--- a/transitions/InvertedPageCurl.glsl
+++ b/transitions/InvertedPageCurl.glsl
@@ -113,7 +113,7 @@ vec4 backside(float yc, vec3 point)
 {
         vec4 color = getFromColor(point.xy);
         float gray = (color.r + color.b + color.g) / 15.0;
-        gray += (8.0 / 10.0) * (pow(1.0 - abs(yc / cylinderRadius), 2.0 / 10.0) / 2.0 + (5.0 / 10.0));
+        gray += (8.0 / 10.0) * (pow(max(0.0, 1.0 - abs(yc / cylinderRadius)), 2.0 / 10.0) / 2.0 + (5.0 / 10.0));
         color.rgb = vec3(gray);
         return color;
 }
@@ -130,8 +130,11 @@ vec4 behindSurface(vec2 p, float yc, vec3 point, mat3 rrotation)
 
         if (yc < 0.0 && point.x >= 0.0 && point.y >= 0.0 && point.x <= 1.0 && point.y <= 1.0 && (hitAngle < PI || amount > 0.5))
         {
-                shado = 1.0 - (sqrt(pow(point.x - 0.5, 2.0) + pow(point.y - 0.5, 2.0)) / (71.0 / 100.0));
-                shado *= pow(-yc / cylinderRadius, 3.0);
+                float dx = point.x - 0.5;
+                float dy = point.y - 0.5;
+                shado = 1.0 - (sqrt(dx * dx + dy * dy) / (71.0 / 100.0));
+                float nyc = -yc / cylinderRadius;
+                shado *= nyc * nyc * nyc;
                 shado *= 0.5;
         }
         else
@@ -195,8 +198,11 @@ vec4 transition(vec2 p) {
         vec4 otherColor;
         if (yc < 0.0)
         {
-                float shado = 1.0 - (sqrt(pow(point.x - 0.5, 2.0) + pow(point.y - 0.5, 2.0)) / 0.71);
-                shado *= pow(-yc / cylinderRadius, 3.0);
+                float dx2 = point.x - 0.5;
+                float dy2 = point.y - 0.5;
+                float shado = 1.0 - (sqrt(dx2 * dx2 + dy2 * dy2) / 0.71);
+                float nyc2 = -yc / cylinderRadius;
+                shado *= nyc2 * nyc2 * nyc2;
                 shado *= 0.5;
                 otherColor = vec4(0.0, 0.0, 0.0, shado);
         }

--- a/transitions/InvertedPageCurl.glsl
+++ b/transitions/InvertedPageCurl.glsl
@@ -36,18 +36,19 @@ in vec2 texCoord;
 
 const float MIN_AMOUNT = -0.16;
 const float MAX_AMOUNT = 1.5;
-float amount = progress * (MAX_AMOUNT - MIN_AMOUNT) + MIN_AMOUNT;
 
 const float PI = 3.141592653589793;
 
 const float scale = 512.0;
 const float sharpness = 3.0;
 
-float cylinderCenter = amount;
-// 360 degrees * amount
-float cylinderAngle = 2.0 * PI * amount;
-
 const float cylinderRadius = 1.0 / PI / 2.0;
+
+// These depend on the progress uniform and must be computed per-fragment.
+// Global initializers with uniforms are invalid in GLSL ES and fail on Mesa.
+float amount;
+float cylinderCenter;
+float cylinderAngle;
 
 vec3 hitPoint(float hitAngle, float yc, vec3 point, mat3 rrotation)
 {
@@ -145,6 +146,9 @@ vec4 behindSurface(vec2 p, float yc, vec3 point, mat3 rrotation)
 }
 
 vec4 transition(vec2 p) {
+  amount = progress * (MAX_AMOUNT - MIN_AMOUNT) + MIN_AMOUNT;
+  cylinderCenter = amount;
+  cylinderAngle = 2.0 * PI * amount;
 
   const float angle = 100.0 * PI / 180.0;
         float c = cos(-angle);

--- a/transitions/InvertedPageCurl.glsl
+++ b/transitions/InvertedPageCurl.glsl
@@ -80,7 +80,7 @@ float distanceToEdge(vec3 point)
 
 vec4 seeThrough(float yc, vec2 p, mat3 rotation, mat3 rrotation)
 {
-        float hitAngle = PI - (acos(yc / cylinderRadius) - cylinderAngle);
+        float hitAngle = PI - (acos(clamp(yc / cylinderRadius, -1.0, 1.0)) - cylinderAngle);
         vec3 point = hitPoint(hitAngle, yc, rotation * vec3(p, 1.0), rrotation);
         if (yc <= 0.0 && (point.x < 0.0 || point.y < 0.0 || point.x > 1.0 || point.y > 1.0))
         {
@@ -121,12 +121,13 @@ vec4 backside(float yc, vec3 point)
 
 vec4 behindSurface(vec2 p, float yc, vec3 point, mat3 rrotation)
 {
-        float shado = (1.0 - ((-cylinderRadius - yc) / amount * 7.0)) / 6.0;
+        float safeAmount = amount >= 0.0 ? max(amount, 1e-4) : min(amount, -1e-4);
+        float shado = (1.0 - ((-cylinderRadius - yc) / safeAmount * 7.0)) / 6.0;
         shado *= 1.0 - abs(point.x - 0.5);
 
         yc = (-cylinderRadius - cylinderRadius - yc);
 
-        float hitAngle = (acos(yc / cylinderRadius) + cylinderAngle) - PI;
+        float hitAngle = (acos(clamp(yc / cylinderRadius, -1.0, 1.0)) + cylinderAngle) - PI;
         point = hitPoint(hitAngle, yc, point, rrotation);
 
         if (yc < 0.0 && point.x >= 0.0 && point.y >= 0.0 && point.x <= 1.0 && point.y <= 1.0 && (hitAngle < PI || amount > 0.5))
@@ -182,7 +183,7 @@ vec4 transition(vec2 p) {
                 return getFromColor(p);
         }
 
-        float hitAngle = (acos(yc / cylinderRadius) + cylinderAngle) - PI;
+        float hitAngle = (acos(clamp(yc / cylinderRadius, -1.0, 1.0)) + cylinderAngle) - PI;
 
         float hitAngleMod = mod(hitAngle, 2.0 * PI);
         if ((hitAngleMod > PI && amount < 0.5) || (hitAngleMod > PI/2.0 && amount < 0.0))

--- a/transitions/tangentMotionBlur.glsl
+++ b/transitions/tangentMotionBlur.glsl
@@ -76,7 +76,8 @@ float KeySpline(float aX, float mX1, float mY1, float mX2, float mY2) {
 
 // norm distribution
 float normpdf(float x) {
-    return exp(-20.*pow(x-.5,2.));
+    float d = x - .5;
+    return exp(-20.*d*d);
 }
 
 vec2 rotateUv(vec2 uv, float angle, vec2 anchor, float zDirection) {


### PR DESCRIPTION
## Summary
Same class of bug as ButterflyWaveScrawler (fixed in #248): `pow(x, y)` is undefined in GLSL when `x < 0`. Browser WebGL handles it, Mesa returns NaN → black pixels.

- **InvertedPageCurl**: replace `pow(point - 0.5, 2.0)` with manual squaring, `pow(-yc/r, 3.0)` with manual cubing, and clamp fractional-exponent base with `max(0.0, ...)`
- **tangentMotionBlur**: replace `pow(x-0.5, 2.0)` with `d*d`

## Test plan
- [ ] Verify preview GIFs render without black frames
- [ ] Verify InvertedPageCurl shadow effect is visually unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)