### PR TITLE
Fix TilesWave "to" image not showing at progress=1

### DIFF
--- a/transitions/TilesWave.glsl
+++ b/transitions/TilesWave.glsl
@@ -13,7 +13,7 @@ vec4 transition(vec2 uv) {
   float countTiles = float(tileCount.x * tileCount.y);
 
   // Diagonal wave from bottom-left to top-right
-  float offset = (tileNum.y + tileNum.x * float(tileCount.y)) / (sqrt(countTiles) * 2.0);
+  float offset = (tileNum.y + tileNum.x * float(tileCount.y)) / countTiles;
   float timeOffset = clamp((progress - offset) * countTiles, 0.0, 0.5);
   float sinTime = 1.0 - abs(cos(fract(timeOffset) * 3.1415926));
 


### PR DESCRIPTION
Thanks to @Yves33 for [reporting this bug and proposing the fix](https://github.com/gl-transitions/gl-transitions/issues/255).

## Bug

In `TilesWave.glsl`, the offset formula divided by `sqrt(countTiles) * 2.0`, which produced offset values greater than 1 for many tiles. For example, with the default 8x8 grid, the last tile gets an offset of ~3.94. As a result, `clamp((progress - offset) * countTiles, 0.0, 0.5)` lands at 0 even when `progress = 1`, so `sinTime` stays at 0 and the "from" image is shown forever instead of transitioning to the "to" image.

## Fix

Divide by `countTiles` instead. This keeps the maximum offset just under 1, so every tile completes its wave by `progress = 1` and correctly shows the "to" image at the end of the transition.

Fixes #255