### PR TITLE
Fix coord-from-in showing distorted image at progress=0

### DIFF
--- a/transitions/coord-from-in.glsl
+++ b/transitions/coord-from-in.glsl
@@ -2,13 +2,13 @@
 // License: MIT
 
 vec4 transition (vec2 uv) {
-  
+
   vec4 coordTo = getToColor(uv);
   vec4 coordFrom = getFromColor(uv);
-  
+
   return mix(
-    getFromColor(coordTo.rg),
-    getToColor(uv),
+    getFromColor(mix(uv, coordTo.rg, progress)),
+    getToColor(mix(coordFrom.rg, uv, progress)),
     progress
   );
 


### PR DESCRIPTION
Thanks to @Yves33 for reporting this issue and proposing the fix!

## The bug

The previous `coord-from-in.glsl` body was:

```glsl
return mix(
  getFromColor(coordTo.rg),
  getToColor(uv),
  progress
);
```

At `progress=0` this returns `getFromColor(coordTo.rg)`, which samples the "from" image at coordinates taken from the *colors* of the "to" image. That made no geometric sense and produced a distorted image instead of the plain "from" image at the start of the transition.

## The fix

Interpolate the sampling coordinates with `mix(uv, coordTo.rg, progress)` so that at `progress=0` the "from" image is returned untouched, and the distortion grows as the transition progresses.

The original author (haiyoucuv, MIT) is preserved in the file header.

Fixes #256