### PR TITLE
Fix CodeQL code injection alerts in preview.yml

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -179,7 +179,12 @@ jobs:
           script: |
             const fs = require('fs');
             const path = require('path');
-            const pr = parseInt(process.env.PR_NUMBER, 10);
+            const prRaw = process.env.PR_NUMBER || '';
+            if (!/^\d+$/.test(prRaw)) {
+              core.setFailed(`Invalid PR number: ${JSON.stringify(prRaw)}`);
+              return;
+            }
+            const pr = Number(prRaw);
             const prefix = process.env.PREFIX;
             const baseUrl = `https://raw.githubusercontent.com/${context.repo.owner}/${context.repo.repo}/preview-assets`;
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -102,10 +102,12 @@ jobs:
 
       - name: Validate and render previews
         if: steps.detect.outputs.files != ''
+        env:
+          FILES: ${{ steps.detect.outputs.files }}
         run: |
           mkdir -p /tmp/previews
           xvfb-run -s "-ac -screen 0 1280x1024x24" bash -c '
-            for file in ${{ steps.detect.outputs.files }}; do
+            for file in $FILES; do
               name=$(basename "$file" .glsl)
               echo "=== Validating $name ==="
               node scripts/preview/validate-transition.js \
@@ -169,12 +171,16 @@ jobs:
       - name: Post preview comment with inline GIFs
         if: steps.upload.outputs.pushed == 'true' && steps.detect.outputs.pr != '' && (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository)
         uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.detect.outputs.pr }}
+          PREFIX: ${{ steps.upload.outputs.prefix }}
+          FILES: ${{ steps.detect.outputs.files }}
         with:
           script: |
             const fs = require('fs');
             const path = require('path');
-            const pr = ${{ steps.detect.outputs.pr }};
-            const prefix = '${{ steps.upload.outputs.prefix }}';
+            const pr = parseInt(process.env.PR_NUMBER, 10);
+            const prefix = process.env.PREFIX;
             const baseUrl = `https://raw.githubusercontent.com/${context.repo.owner}/${context.repo.repo}/preview-assets`;
 
             const comments = await github.paginate(github.rest.issues.listComments, {
@@ -186,7 +192,7 @@ jobs:
               c.user.type === 'Bot' && c.body.includes('## Transition Preview')
             );
 
-            const files = '${{ steps.detect.outputs.files }}'.split(' ').filter(Boolean);
+            const files = (process.env.FILES || '').split(' ').filter(Boolean);
             let body = '## Transition Preview\n\n';
 
             for (const file of files) {


### PR DESCRIPTION
## Summary

CodeQL flagged two "Code injection" alerts in `.github/workflows/preview.yml`. The `Validate and render previews` step and the `Post preview comment with inline GIFs` step inlined `${{ steps.detect.outputs.files }}` (and the related `pr`/`prefix` step outputs, which themselves derive from `inputs.transition` / `inputs.pr_number` on `workflow_dispatch`) directly into shell and JS scripts.

An attacker triggering `workflow_dispatch` with a crafted transition name could break out of the surrounding quotes and execute arbitrary code in the runner.

## Fix

The standard mitigation: route every step output that flows into a script through the step's `env:` block, and read it at runtime instead of letting GitHub Actions template-expand it inside the script body.

- `Validate and render previews`: added `env: FILES: ${{ steps.detect.outputs.files }}`. The single-quoted `bash -c '...'` body now references `$FILES`, expanded by the inner bash at runtime.
- `Post preview comment with inline GIFs`: added `env:` with `PR_NUMBER`, `PREFIX`, `FILES`. The github-script body now reads them via `process.env.X`. `pr` is restored to a number with `parseInt(..., 10)` since it was previously inlined as a literal integer.

The same env-var pattern is applied to all step outputs flowing into scripts in this workflow, so the values never undergo Actions template expansion inside script bodies.