### PR TITLE
Add explicit GITHUB_TOKEN permissions to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}

--- a/.github/workflows/test-preview.yml
+++ b/.github/workflows/test-preview.yml
@@ -13,6 +13,9 @@ on:
       - '.github/workflows/test-preview.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes the three open CodeQL alerts (`actions/missing-workflow-permissions`) on `ci.yml` and `test-preview.yml` by adding a workflow-level least-privilege permissions block:

```yaml
permissions:
  contents: read
```

- **ci.yml**: covers the `build` and `check-publish` jobs, which only read the repo. The `publish` job is unchanged — its job-level `contents: write` / `id-token: write` overrides the workflow default, so npm publish with provenance and tag pushing keep working.
- **test-preview.yml**: covers the `test` job, which only checks out, renders previews, and uploads artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)